### PR TITLE
Добавил .gitignore файл со списком игнорируемых файлов для git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+.idea
+
+**/local_config.py
+docker-compose.override.yml
+persistent
+pdf_files


### PR DESCRIPTION
Файлы / маски имён файлов, перечисленные в `.gitignore` файле, не будут синхронизироваться (например, pdf_files и *.pyc файлы не являются частью проекта, поэтому в git их синхрониховать не нужно)