### PR TITLE
Добавил список зависимостей (requirements.txt)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+flask
+flask-admin
+
+mysql-connector
+alembic
+flask-sqlalchemy
+flask-migrate
+
+flask-script
+flask-security
+flask-wtf


### PR DESCRIPTION
Проект должен явно указывать какие зависимости он использует, так что на новом компьютере можно было бы легко установить ("развернуть") проект. В Python договорились использовать файл `requirements.txt`, в котором можно просто перечислить все зависимости (при необходимости, можно требовать конкретную версию модуля, например, дописав `==1.0.0` после названия).